### PR TITLE
PIT-04: Fix mongo register

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.apache.commons:commons-lang3:3.12.0'
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+	runtimeOnly 'com.h2database:h2'
 
 	compileOnly 'org.projectlombok:lombok'
 

--- a/src/main/java/com/miu/pasteit/PasteItApplication.java
+++ b/src/main/java/com/miu/pasteit/PasteItApplication.java
@@ -1,9 +1,19 @@
 package com.miu.pasteit;
 
+import com.miu.pasteit.repository.PasteRepository;
+import com.miu.pasteit.repository.UserRepository;
+import com.miu.pasteit.repository.UserRolesRepository;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
+@EnableMongoRepositories("com.miu.pasteit.repository")
+@EnableJpaRepositories(excludeFilters =
+@ComponentScan.Filter(type = FilterType.REGEX, pattern = "com.miu.pasteit.repository.*" ))
 @SpringBootApplication
 @EnableConfigurationProperties
 public class PasteItApplication {


### PR DESCRIPTION
I have got minor error:

The bean 'pasteRepository', defined in com.miu.pasteit.repository.PasteRepository defined in @EnableMongoRepositories declared on MongoRepositoriesRegistrar.EnableMongoRepositoriesConfiguration, could not be registered. A bean with that name has already been defined in com.miu.pasteit.repository.PasteRepository defined in @EnableJpaRepositories declared on JpaRepositoriesRegistrar.EnableJpaRepositoriesConfiguration and overriding is disabled.

Action:

Consider renaming one of the beans or enabling overriding by setting spring.main.allow-bean-definition-overriding=true


> Task :PasteItApplication.main() FAILED

Execution failed for task ':PasteItApplication.main()'.
> Process 'command '/Applications/IntelliJ IDEA CE.app/Contents/jbr/Contents/Home/bin/java'' finished with non-zero exit value 1

I have fixed the above issues.

FYI: I have added the h2 to test with in memory database. 

you need to fix one issue though the error is related to activityId as shown below:

org.springframework.data.mapping.MappingException: Ambiguous field mapping detected! Both @javax.persistence.Id()protected java.lang.String com.miu.pasteit.model.entity.common.ActivityCommon.activityId and @javax.persistence.Id()private java.lang.String com.miu.pasteit.model.entity.activity.ActivityPaste.activityId map to the same field name activityId! Disambiguate using @Field annotation!

@rimonmostafiz 